### PR TITLE
Replaces "pod update" with "pod repo update"

### DIFF
--- a/src/main/java/com/thoughtsonmobile/jenkins/cocoapods/CocoaPodsBuilder.java
+++ b/src/main/java/com/thoughtsonmobile/jenkins/cocoapods/CocoaPodsBuilder.java
@@ -104,10 +104,10 @@ public class CocoaPodsBuilder extends Builder {
       env.putAll(build.getBuildVariables());
 
       final ArgumentListBuilder args = new ArgumentListBuilder();
-      args.addTokenized("pod install");
+      args.addTokenized("pod repo update");
 
       final ArgumentListBuilder args2 = new ArgumentListBuilder();
-      args2.addTokenized("pod update");
+      args2.addTokenized("pod install");
 
       final int resultInstall =
         launcher.decorateFor(build.getBuiltOn()).launch().cmds(args).envs(env)


### PR DESCRIPTION
"pod update" checks if there are new versions of the installed pods available and uses them instead.

"pod repo update" updates the spec repositories to ensure the pods specified in the lockfile are found by the CocoaPods.

Using "pod update" is potentially dangerous as it might change the version of the pods in use.
