### PR TITLE
Support for pod files not in root of the project

### DIFF
--- a/src/main/resources/com/thoughtsonmobile/jenkins/cocoapods/CocoaPodsBuilder/config.jelly
+++ b/src/main/resources/com/thoughtsonmobile/jenkins/cocoapods/CocoaPodsBuilder/config.jelly
@@ -18,4 +18,7 @@
   <f:entry title="${%Verbose}" field="verbose">
     <f:checkbox />
   </f:entry>
+  <f:entry title="${%Project Root}" field="projectRoot" >
+    <f:textbox default="." />
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/com/thoughtsonmobile/jenkins/cocoapods/CocoaPodsBuilder/help-projectroot.html
+++ b/src/main/resources/com/thoughtsonmobile/jenkins/cocoapods/CocoaPodsBuilder/help-projectroot.html
@@ -1,0 +1,20 @@
+<!--
+
+      Copyright 2014 http://www.matrix.org/
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<div>
+  The directory you Xcode prjoject resides in and where cocoapods should be run
+</div>


### PR DESCRIPTION
Adds a config option to control which directory cocoapods is run in. Also add public getters for the config options so they aren't reset to their defaults each time the plugin is configured.
